### PR TITLE
Wiz: Upgrade minimist to 0.2.4 (resolves 1 finding)

### DIFF
--- a/frankoyarn/package.json
+++ b/frankoyarn/package.json
@@ -5,7 +5,7 @@
     "axios": "0.21.0",
     "lodash": "4.17.11",
     "merge": "1.2.1",
-    "minimist": "0.0.8",
+    "minimist": "0.2.4",
     "qs": "6.5.2",
     "serialize-javascript": "2.1.1",
     "underscore": "1.12.0",

--- a/frankoyarn/yarn.lock
+++ b/frankoyarn/yarn.lock
@@ -1018,10 +1018,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:0.0.8":
-  version: 0.0.8
-  resolution: "minimist@npm:0.0.8"
-  checksum: 10c0/d0a998c3042922dbcd5f23566b52811d6977649ad089fd75dd89e8a9bff27634194900818b2dfb1b873f204edb902d0c8cdea9cb8dca8488b301f69bd522d5dc
+"minimist@npm:0.2.4":
+  version: 0.2.4
+  resolution: "minimist@npm:0.2.4"
+  checksum: 10c0/6a8e8f4afa4a60d578b3eddabef1e3a40f3aa308290b17a55e060bbacfba7a575fd77f310969dd6b514c24251438a43039aafa0d6c9a3471ac2b5b45027d3369
   languageName: node
   linkType: hard
 
@@ -1709,7 +1709,7 @@ __metadata:
     axios: "npm:0.21.0"
     lodash: "npm:4.17.11"
     merge: "npm:1.2.1"
-    minimist: "npm:0.0.8"
+    minimist: "npm:0.2.4"
     qs: "npm:6.5.2"
     serialize-javascript: "npm:2.1.1"
     underscore: "npm:1.12.0"


### PR DESCRIPTION
<a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/banners/pull_request_banner_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/banners/pull_request_banner_light.svg"><img align="top" valign="top" alt="Wiz Remediation Pull Request Banner" title="Wiz Remediation Pull Request Banner" src="https://assets.wiz.io/wiz-code/banners/pull_request_banner_light.svg"></picture></a>

### Wiz has created this PR to fix 1 finding detected in this project

Changes were made to the following file(s):

- `frankoyarn/package.json`
- `frankoyarn/yarn.lock`

**Vulnerabilities:**
| Component | Findings | Locations |
| --------- | -------- | --------- |
| **minimist**<br>0.0.8 → 0.2.4 | <a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/critical_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/critical_light.svg"><img align="top" valign="top" alt="Critical" title="Critical" src="https://assets.wiz.io/wiz-code/short_severity_tags/critical_light.svg"></picture></a> [CVE-2021-44906](https://nvd.nist.gov/vuln/detail/CVE-2021-44906) | `/frankoyarn/package.json` |


To detect these findings earlier in the dev lifecycle, try using *<a href="https://marketplace.visualstudio.com/items?itemName=WizCloud.wiz-vscode" target="_blank">Wiz Code VS Code Extension.</a>*
