### PR TITLE
Wiz: Upgrade minimist to 1.2.6 (resolves 1 finding)

### DIFF
--- a/yarnversion3/package.json
+++ b/yarnversion3/package.json
@@ -5,7 +5,7 @@
     "axios": "0.18.0",
     "lodash": "4.17.19",
     "marked": "1.2.2",
-    "minimist": "1.2.5",
+    "minimist": "1.2.6",
     "wrangler": "3.18.0"
   }
 }

--- a/yarnversion3/yarn.lock
+++ b/yarnversion3/yarn.lock
@@ -1028,10 +1028,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:1.2.5":
-  version: 1.2.5
-  resolution: "minimist@npm:1.2.5"
-  checksum: 86706ce5b36c16bfc35c5fe3dbb01d5acdc9a22f2b6cc810b6680656a1d2c0e44a0159c9a3ba51fb072bb5c203e49e10b51dcd0eec39c481f4c42086719bae52
+"minimist@npm:1.2.6":
+  version: 1.2.6
+  resolution: "minimist@npm:1.2.6"
+  checksum: d15428cd1e11eb14e1233bcfb88ae07ed7a147de251441d61158619dfb32c4d7e9061d09cab4825fdee18ecd6fce323228c8c47b5ba7cd20af378ca4048fb3fb
   languageName: node
   linkType: hard
 
@@ -1698,7 +1698,7 @@ __metadata:
     axios: 0.18.0
     lodash: 4.17.19
     marked: 1.2.2
-    minimist: 1.2.5
+    minimist: 1.2.6
     wrangler: 3.18.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
<a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/banners/pull_request_banner_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/banners/pull_request_banner_light.svg"><img align="top" valign="top" alt="Wiz Remediation Pull Request Banner" title="Wiz Remediation Pull Request Banner" src="https://assets.wiz.io/wiz-code/banners/pull_request_banner_light.svg"></picture></a>

### Wiz has created this PR to fix 1 finding detected in this project

Changes were made to the following file(s):

- `yarnversion3/package.json`
- `yarnversion3/yarn.lock`

**Vulnerabilities:**
| Component | Findings | Locations |
| --------- | -------- | --------- |
| **minimist**<br>1.2.5 → 1.2.6 | <a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/critical_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/critical_light.svg"><img align="top" valign="top" alt="Critical" title="Critical" src="https://assets.wiz.io/wiz-code/short_severity_tags/critical_light.svg"></picture></a> [CVE-2021-44906](https://nvd.nist.gov/vuln/detail/CVE-2021-44906) | `/yarnversion3/package.json` |


To detect these findings earlier in the dev lifecycle, try using *<a href="https://marketplace.visualstudio.com/items?itemName=WizCloud.wiz-vscode" target="_blank">Wiz Code VS Code Extension.</a>*
