### PR TITLE
Wiz: Upgrade underscore to 1.12.1 (resolves 1 finding)

### DIFF
--- a/frankoyarn/package.json
+++ b/frankoyarn/package.json
@@ -8,7 +8,7 @@
     "minimist": "0.0.8",
     "qs": "6.5.2",
     "serialize-javascript": "2.1.1",
-    "underscore": "1.12.0",
+    "underscore": "1.12.1",
     "wrangler": "3.18.0"
   }
 }


### PR DESCRIPTION
<a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/banners/pull_request_banner_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/banners/pull_request_banner_light.svg"><img align="top" valign="top" alt="Wiz Remediation Pull Request Banner" title="Wiz Remediation Pull Request Banner" src="https://assets.wiz.io/wiz-code/banners/pull_request_banner_light.svg"></picture></a>

### Wiz has created this PR to fix 1 finding detected in this project

Changes were made to the following file(s):

- `/frankoyarn/package.json`

**Vulnerabilities:**
| Component | Findings | Locations |
| --------- | -------- | --------- |
| **underscore**<br>1.12.0 → 1.12.1 | <a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"><img align="top" valign="top" alt="High" title="High" src="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"></picture></a> [CVE-2021-23358](https://nvd.nist.gov/vuln/detail/CVE-2021-23358) | `/frankoyarn/package.json` |


To detect these findings earlier in the dev lifecycle, try using *<a href="https://marketplace.visualstudio.com/items?itemName=WizCloud.wiz-vscode" target="_blank">Wiz Code VS Code Extension.</a>*
