### PR TITLE
Wiz: Upgrade serialize-javascript to 3.1.0 (resolves 1 finding)

### DIFF
--- a/frankoyarn/package.json
+++ b/frankoyarn/package.json
@@ -7,7 +7,7 @@
     "merge": "1.2.1",
     "minimist": "0.0.8",
     "qs": "6.5.2",
-    "serialize-javascript": "2.1.1",
+    "serialize-javascript": "3.1.0",
     "underscore": "1.12.0",
     "wrangler": "3.18.0"
   }

--- a/frankoyarn/yarn.lock
+++ b/frankoyarn/yarn.lock
@@ -1261,6 +1261,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"randombytes@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "randombytes@npm:2.1.0"
+  dependencies:
+    safe-buffer: "npm:^5.1.0"
+  checksum: 10c0/50395efda7a8c94f5dffab564f9ff89736064d32addf0cc7e8bf5e4166f09f8ded7a0849ca6c2d2a59478f7d90f78f20d8048bca3cdf8be09d8e8a10790388f3
+  languageName: node
+  linkType: hard
+
 "readdirp@npm:~3.6.0":
   version: 3.6.0
   resolution: "readdirp@npm:3.6.0"
@@ -1313,6 +1322,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"safe-buffer@npm:^5.1.0":
+  version: 5.2.1
+  resolution: "safe-buffer@npm:5.2.1"
+  checksum: 10c0/6501914237c0a86e9675d4e51d89ca3c21ffd6a31642efeba25ad65720bce6921c9e7e974e5be91a786b25aa058b5303285d3c15dbabf983a919f5f630d349f3
+  languageName: node
+  linkType: hard
+
 "safer-buffer@npm:>= 2.1.2 < 3.0.0":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
@@ -1339,10 +1355,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serialize-javascript@npm:2.1.1":
-  version: 2.1.1
-  resolution: "serialize-javascript@npm:2.1.1"
-  checksum: 10c0/cf00beeb37b8e06aa6f6cecff432cf5a52e601effc4f3be5c91352a06d880e0016bdc7df32d2b396f698fe77deb97eaa2eafee735e285666b765502e414fd1aa
+"serialize-javascript@npm:3.1.0":
+  version: 3.1.0
+  resolution: "serialize-javascript@npm:3.1.0"
+  dependencies:
+    randombytes: "npm:^2.1.0"
+  checksum: 10c0/ca8a6bb29891e524e36451d685827ab7e7f50171e5aebe99504d07ae97308a9faa880e0df0517d75ed8efb09991454eb8cb969cecfad82478fc0591938a3909c
   languageName: node
   linkType: hard
 
@@ -1711,7 +1729,7 @@ __metadata:
     merge: "npm:1.2.1"
     minimist: "npm:0.0.8"
     qs: "npm:6.5.2"
-    serialize-javascript: "npm:2.1.1"
+    serialize-javascript: "npm:3.1.0"
     underscore: "npm:1.12.0"
     wrangler: "npm:3.18.0"
   languageName: unknown


### PR DESCRIPTION
<a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/banners/pull_request_banner_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/banners/pull_request_banner_light.svg"><img align="top" valign="top" alt="Wiz Remediation Pull Request Banner" title="Wiz Remediation Pull Request Banner" src="https://assets.wiz.io/wiz-code/banners/pull_request_banner_light.svg"></picture></a>

### Wiz has created this PR to fix 1 finding detected in this project

Changes were made to the following file(s):

- `frankoyarn/package.json`
- `frankoyarn/yarn.lock`

**Vulnerabilities:**
| Component | Findings | Locations |
| --------- | -------- | --------- |
| **serialize-javascript**<br>2.1.1 → 3.1.0 | <a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"><img align="top" valign="top" alt="High" title="High" src="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"></picture></a> [CVE-2020-7660](https://nvd.nist.gov/vuln/detail/CVE-2020-7660) | `/frankoyarn/package.json` |


To detect these findings earlier in the dev lifecycle, try using *<a href="https://marketplace.visualstudio.com/items?itemName=WizCloud.wiz-vscode" target="_blank">Wiz Code VS Code Extension.</a>*
