### PR TITLE
Wiz: Upgrade lodash to 4.17.21 (resolves 1 finding)

### DIFF
--- a/failinglockfile/package.json
+++ b/failinglockfile/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "axios": "^999.999.999",
     "immer": "^9.0.5",
-    "lodash": "4.17.19",
+    "lodash": "4.17.21",
     "wrangler": "3.18.0"
   }
 }


### PR DESCRIPTION
<a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/banners/pull_request_banner_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/banners/pull_request_banner_light.svg"><img align="top" valign="top" alt="Wiz Remediation Pull Request Banner" title="Wiz Remediation Pull Request Banner" src="https://assets.wiz.io/wiz-code/banners/pull_request_banner_light.svg"></picture></a>

### Wiz has created this PR to fix 1 finding detected in this project

Changes were made to the following file(s):

- `/failinglockfile/package.json`

**Vulnerabilities:**
| Component | Findings | Locations |
| --------- | -------- | --------- |
| **lodash**<br>4.17.19 → 4.17.21 | <a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"><img align="top" valign="top" alt="High" title="High" src="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"></picture></a> [CVE-2021-23337](https://nvd.nist.gov/vuln/detail/CVE-2021-23337) | `/failinglockfile/package.json` |


To detect these findings earlier in the dev lifecycle, try using *<a href="https://marketplace.visualstudio.com/items?itemName=WizCloud.wiz-vscode" target="_blank">Wiz Code VS Code Extension.</a>*
