### PR TITLE
Wiz: Upgrade multiple dependencies (resolves 68 findings)

### DIFF
--- a/demo-app/application/package.json
+++ b/demo-app/application/package.json
@@ -11,7 +11,7 @@
     "core-js": "^3.25.0",
     "express": "^4.18.1",
     "vue": "^3.2.38",
-    "wrangler": "3.18.0"
+    "wrangler": "3.19.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.16",

--- a/failinglockfile/package.json
+++ b/failinglockfile/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "axios": "^499.999.999",
     "immer": "^9.0.5",
-    "lodash": "4.17.19",
-    "wrangler": "3.18.0"
+    "lodash": "4.17.21",
+    "wrangler": "3.19.0"
   }
 }

--- a/failinglockfile2/package.json
+++ b/failinglockfile2/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "axios": "^999.999.999",
     "immer": "^9.0.5",
-    "lodash": "4.17.19",
-    "wrangler": "3.18.0"
+    "lodash": "4.17.21",
+    "wrangler": "3.19.0"
   }
 }

--- a/frankoyarn/package.json
+++ b/frankoyarn/package.json
@@ -2,13 +2,13 @@
   "name": "yarntest",
   "packageManager": "yarn@4.9.2",
   "dependencies": {
-    "axios": "0.21.0",
-    "lodash": "4.17.11",
+    "axios": "0.30.2",
+    "lodash": "4.17.21",
     "merge": "1.2.1",
-    "minimist": "0.0.8",
+    "minimist": "0.2.4",
     "qs": "6.5.2",
     "serialize-javascript": "2.1.1",
-    "underscore": "1.12.0",
-    "wrangler": "3.18.0"
+    "underscore": "1.12.1",
+    "wrangler": "3.19.0"
   }
 }

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -10,6 +10,6 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "react-scripts": "^4.0.3"
+    "react-scripts": "5.0.0-next.47"
   }
 }

--- a/poetry/pyproject.toml
+++ b/poetry/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "requests (==2.32.3)",
-    "pyyaml (==5.3)",
+    "pyyaml (==5.4)",
     "jinja2 (==2.10.1)"
 ]
 

--- a/yarntest/package.json
+++ b/yarntest/package.json
@@ -2,13 +2,13 @@
   "name": "yarntest",
   "packageManager": "yarn@4.9.2",
   "dependencies": {
-    "axios": "0.21.0",
-    "lodash": "4.17.11",
+    "axios": "0.30.2",
+    "lodash": "4.17.21",
     "merge": "1.2.1",
-    "minimist": "0.0.8",
+    "minimist": "0.2.4",
     "qs": "6.5.2",
     "serialize-javascript": "2.1.1",
-    "underscore": "1.12.0",
-    "wrangler": "3.18.0"
+    "underscore": "1.12.1",
+    "wrangler": "3.19.0"
   }
 }

--- a/yarnversion3/package.json
+++ b/yarnversion3/package.json
@@ -2,10 +2,10 @@
   "name": "yarnversion3",
   "packageManager": "yarn@3.6.4",
   "dependencies": {
-    "axios": "0.18.0",
-    "lodash": "4.17.19",
-    "marked": "1.2.2",
-    "minimist": "1.2.5",
-    "wrangler": "3.18.0"
+    "axios": "0.30.2",
+    "lodash": "4.17.21",
+    "marked": "4.0.10",
+    "minimist": "1.2.6",
+    "wrangler": "3.19.0"
   }
 }


### PR DESCRIPTION
<a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/banners/pull_request_banner_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/banners/pull_request_banner_light.svg"><img align="top" valign="top" alt="Wiz Remediation Pull Request Banner" title="Wiz Remediation Pull Request Banner" src="https://assets.wiz.io/wiz-code/banners/pull_request_banner_light.svg"></picture></a>

### Wiz has created this PR to fix 68 findings detected in this project

Changes were made to the following file(s):

- `/demo-app/application/package.json`
- `/failinglockfile/package.json`
- `/failinglockfile2/package.json`
- `/frankoyarn/package.json`
- `/nodejs/package.json`
- `/poetry/pyproject.toml`
- `/yarntest/package.json`
- `/yarnversion3/package.json`

**Vulnerabilities:**
| Component | Findings | Locations |
| --------- | -------- | --------- |
| **ansi-html**<br>0.0.7 → 5.0.0-next.47 | <a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"><img align="top" valign="top" alt="High" title="High" src="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"></picture></a> [CVE-2021-23424](https://nvd.nist.gov/vuln/detail/CVE-2021-23424) | `/nodejs/package.json` |
| **axios**<br>0.18.0 → 0.30.2 | <a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"><img align="top" valign="top" alt="High" title="High" src="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"></picture></a> [CVE-2021-3749](https://nvd.nist.gov/vuln/detail/CVE-2021-3749)<br><a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"><img align="top" valign="top" alt="High" title="High" src="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"></picture></a> [CVE-2025-58754](https://nvd.nist.gov/vuln/detail/CVE-2025-58754)<br><a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"><img align="top" valign="top" alt="High" title="High" src="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"></picture></a> [CVE-2019-10742](https://nvd.nist.gov/vuln/detail/CVE-2019-10742)<br><a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"><img align="top" valign="top" alt="High" title="High" src="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"></picture></a> [CVE-2025-27152](https://nvd.nist.gov/vuln/detail/CVE-2025-27152)<br><a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/medium_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/medium_light.svg"><img align="top" valign="top" alt="Medium" title="Medium" src="https://assets.wiz.io/wiz-code/short_severity_tags/medium_light.svg"></picture></a> [CVE-2020-28168](https://nvd.nist.gov/vuln/detail/CVE-2020-28168)<br><a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/medium_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/medium_light.svg"><img align="top" valign="top" alt="Medium" title="Medium" src="https://assets.wiz.io/wiz-code/short_severity_tags/medium_light.svg"></picture></a> [CVE-2023-45857](https://nvd.nist.gov/vuln/detail/CVE-2023-45857) | `/yarnversion3/package.json` |
| **axios**<br>0.21.0 → 0.30.2 | <a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"><img align="top" valign="top" alt="High" title="High" src="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"></picture></a> [CVE-2021-3749](https://nvd.nist.gov/vuln/detail/CVE-2021-3749)<br><a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"><img align="top" valign="top" alt="High" title="High" src="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"></picture></a> [CVE-2025-27152](https://nvd.nist.gov/vuln/detail/CVE-2025-27152)<br><a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"><img align="top" valign="top" alt="High" title="High" src="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"></picture></a> [CVE-2025-58754](https://nvd.nist.gov/vuln/detail/CVE-2025-58754)<br><a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/medium_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/medium_light.svg"><img align="top" valign="top" alt="Medium" title="Medium" src="https://assets.wiz.io/wiz-code/short_severity_tags/medium_light.svg"></picture></a> [CVE-2023-45857](https://nvd.nist.gov/vuln/detail/CVE-2023-45857)<br><a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/medium_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/medium_light.svg"><img align="top" valign="top" alt="Medium" title="Medium" src="https://assets.wiz.io/wiz-code/short_severity_tags/medium_light.svg"></picture></a> [CVE-2020-28168](https://nvd.nist.gov/vuln/detail/CVE-2020-28168) | `/frankoyarn/package.json`<br>`/yarntest/package.json` |
| **braces**<br>2.3.2 → 5.0.0-next.47 | <a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"><img align="top" valign="top" alt="High" title="High" src="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"></picture></a> [CVE-2024-4068](https://nvd.nist.gov/vuln/detail/CVE-2024-4068) | `/nodejs/package.json` |
| **immer**<br>8.0.1 → 5.0.0-next.47 | <a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/critical_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/critical_light.svg"><img align="top" valign="top" alt="Critical" title="Critical" src="https://assets.wiz.io/wiz-code/short_severity_tags/critical_light.svg"></picture></a> [CVE-2021-3757](https://nvd.nist.gov/vuln/detail/CVE-2021-3757)<br><a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/critical_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/critical_light.svg"><img align="top" valign="top" alt="Critical" title="Critical" src="https://assets.wiz.io/wiz-code/short_severity_tags/critical_light.svg"></picture></a> [CVE-2021-23436](https://nvd.nist.gov/vuln/detail/CVE-2021-23436) | `/nodejs/package.json` |
| **loader-utils**<br>2.0.0 → 5.0.0-next.47 | <a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/critical_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/critical_light.svg"><img align="top" valign="top" alt="Critical" title="Critical" src="https://assets.wiz.io/wiz-code/short_severity_tags/critical_light.svg"></picture></a> [CVE-2022-37601](https://nvd.nist.gov/vuln/detail/CVE-2022-37601)<br><a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"><img align="top" valign="top" alt="High" title="High" src="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"></picture></a> [CVE-2022-37599](https://nvd.nist.gov/vuln/detail/CVE-2022-37599)<br><a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"><img align="top" valign="top" alt="High" title="High" src="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"></picture></a> [CVE-2022-37603](https://nvd.nist.gov/vuln/detail/CVE-2022-37603) | `/nodejs/package.json` |
| **lodash**<br>4.17.11 → 4.17.21 | <a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/critical_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/critical_light.svg"><img align="top" valign="top" alt="Critical" title="Critical" src="https://assets.wiz.io/wiz-code/short_severity_tags/critical_light.svg"></picture></a> [CVE-2019-10744](https://nvd.nist.gov/vuln/detail/CVE-2019-10744)<br><a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"><img align="top" valign="top" alt="High" title="High" src="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"></picture></a> [CVE-2020-8203](https://nvd.nist.gov/vuln/detail/CVE-2020-8203)<br><a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"><img align="top" valign="top" alt="High" title="High" src="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"></picture></a> [CVE-2021-23337](https://nvd.nist.gov/vuln/detail/CVE-2021-23337)<br><a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/medium_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/medium_light.svg"><img align="top" valign="top" alt="Medium" title="Medium" src="https://assets.wiz.io/wiz-code/short_severity_tags/medium_light.svg"></picture></a> [CVE-2020-28500](https://nvd.nist.gov/vuln/detail/CVE-2020-28500) | `/frankoyarn/package.json`<br>`/yarntest/package.json` |
| **lodash**<br>4.17.19 → 4.17.21 | <a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"><img align="top" valign="top" alt="High" title="High" src="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"></picture></a> [CVE-2021-23337](https://nvd.nist.gov/vuln/detail/CVE-2021-23337)<br><a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/medium_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/medium_light.svg"><img align="top" valign="top" alt="Medium" title="Medium" src="https://assets.wiz.io/wiz-code/short_severity_tags/medium_light.svg"></picture></a> [CVE-2020-28500](https://nvd.nist.gov/vuln/detail/CVE-2020-28500) | `/failinglockfile/package.json`<br>`/failinglockfile2/package.json`<br>`/yarnversion3/package.json` |
| **marked**<br>1.2.2 → 4.0.10 | <a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"><img align="top" valign="top" alt="High" title="High" src="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"></picture></a> [CVE-2022-21680](https://nvd.nist.gov/vuln/detail/CVE-2022-21680)<br><a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"><img align="top" valign="top" alt="High" title="High" src="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"></picture></a> [CVE-2021-21306](https://nvd.nist.gov/vuln/detail/CVE-2021-21306)<br><a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"><img align="top" valign="top" alt="High" title="High" src="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"></picture></a> [CVE-2022-21681](https://nvd.nist.gov/vuln/detail/CVE-2022-21681) | `/yarnversion3/package.json` |
| **minimist**<br>0.0.8 → 0.2.4 | <a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/critical_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/critical_light.svg"><img align="top" valign="top" alt="Critical" title="Critical" src="https://assets.wiz.io/wiz-code/short_severity_tags/critical_light.svg"></picture></a> [CVE-2021-44906](https://nvd.nist.gov/vuln/detail/CVE-2021-44906)<br><a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/medium_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/medium_light.svg"><img align="top" valign="top" alt="Medium" title="Medium" src="https://assets.wiz.io/wiz-code/short_severity_tags/medium_light.svg"></picture></a> [CVE-2020-7598](https://nvd.nist.gov/vuln/detail/CVE-2020-7598) | `/frankoyarn/package.json`<br>`/yarntest/package.json` |
| **minimist**<br>1.2.5 → 1.2.6 | <a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/critical_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/critical_light.svg"><img align="top" valign="top" alt="Critical" title="Critical" src="https://assets.wiz.io/wiz-code/short_severity_tags/critical_light.svg"></picture></a> [CVE-2021-44906](https://nvd.nist.gov/vuln/detail/CVE-2021-44906) | `/yarnversion3/package.json` |
| **node-forge**<br>0.10.0 → 5.0.0-next.47 | <a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"><img align="top" valign="top" alt="High" title="High" src="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"></picture></a> [CVE-2022-24771](https://nvd.nist.gov/vuln/detail/CVE-2022-24771)<br><a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"><img align="top" valign="top" alt="High" title="High" src="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"></picture></a> [CVE-2022-24772](https://nvd.nist.gov/vuln/detail/CVE-2022-24772)<br><a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/medium_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/medium_light.svg"><img align="top" valign="top" alt="Medium" title="Medium" src="https://assets.wiz.io/wiz-code/short_severity_tags/medium_light.svg"></picture></a> [CVE-2022-0122](https://nvd.nist.gov/vuln/detail/CVE-2022-0122)<br><a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/medium_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/medium_light.svg"><img align="top" valign="top" alt="Medium" title="Medium" src="https://assets.wiz.io/wiz-code/short_severity_tags/medium_light.svg"></picture></a> [CVE-2022-24773](https://nvd.nist.gov/vuln/detail/CVE-2022-24773)<br><a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/low_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/low_light.svg"><img align="top" valign="top" alt="Low" title="Low" src="https://assets.wiz.io/wiz-code/short_severity_tags/low_light.svg"></picture></a> [GHSA-5rrq-pxf6-6jx5](https://github.com/advisories/GHSA-5rrq-pxf6-6jx5)<br><a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/low_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/low_light.svg"><img align="top" valign="top" alt="Low" title="Low" src="https://assets.wiz.io/wiz-code/short_severity_tags/low_light.svg"></picture></a> [GHSA-gf8q-jrpm-jvxq](https://github.com/advisories/GHSA-gf8q-jrpm-jvxq) | `/nodejs/package.json` |
| **pyyaml**<br>5.3 → 5.4 | <a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/critical_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/critical_light.svg"><img align="top" valign="top" alt="Critical" title="Critical" src="https://assets.wiz.io/wiz-code/short_severity_tags/critical_light.svg"></picture></a> [CVE-2020-1747](https://nvd.nist.gov/vuln/detail/CVE-2020-1747)<br><a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/critical_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/critical_light.svg"><img align="top" valign="top" alt="Critical" title="Critical" src="https://assets.wiz.io/wiz-code/short_severity_tags/critical_light.svg"></picture></a> [CVE-2020-14343](https://nvd.nist.gov/vuln/detail/CVE-2020-14343) | `/poetry/pyproject.toml` |
| **shell-quote**<br>1.7.2 → 5.0.0-next.47 | <a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/critical_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/critical_light.svg"><img align="top" valign="top" alt="Critical" title="Critical" src="https://assets.wiz.io/wiz-code/short_severity_tags/critical_light.svg"></picture></a> [CVE-2021-42740](https://nvd.nist.gov/vuln/detail/CVE-2021-42740) | `/nodejs/package.json` |
| **underscore**<br>1.12.0 → 1.12.1 | <a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"><img align="top" valign="top" alt="High" title="High" src="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"></picture></a> [CVE-2021-23358](https://nvd.nist.gov/vuln/detail/CVE-2021-23358) | `/frankoyarn/package.json`<br>`/yarntest/package.json` |
| **wrangler**<br>3.18.0 → 3.19.0 | <a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"><img align="top" valign="top" alt="High" title="High" src="https://assets.wiz.io/wiz-code/short_severity_tags/high_light.svg"></picture></a> [CVE-2023-7080](https://nvd.nist.gov/vuln/detail/CVE-2023-7080)<br><a><picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/medium_dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://assets.wiz.io/wiz-code/short_severity_tags/medium_light.svg"><img align="top" valign="top" alt="Medium" title="Medium" src="https://assets.wiz.io/wiz-code/short_severity_tags/medium_light.svg"></picture></a> [CVE-2023-7079](https://nvd.nist.gov/vuln/detail/CVE-2023-7079) | `/demo-app/application/package.json`<br>`/failinglockfile/package.json`<br>`/failinglockfile2/package.json`<br>`/frankoyarn/package.json`<br>`/yarntest/package.json`<br>`/yarnversion3/package.json` |


To detect these findings earlier in the dev lifecycle, try using *<a href="https://marketplace.visualstudio.com/items?itemName=WizCloud.wiz-vscode" target="_blank">Wiz Code VS Code Extension.</a>*
